### PR TITLE
Fix wordbank recipe.

### DIFF
--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/WordBankRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/WordBankRecipe.java
@@ -55,7 +55,7 @@ public class WordBankRecipe extends InputRecipe {
 		if (!ItemUtils.isValidItem(toApply)) {
 			return false;
 		}
-		if (ItemUtils.getDisplayName(toApply) != null) {
+		if (!ItemUtils.getDisplayName(toApply).isEmpty()) {
 			return false;
 		}
 		ItemMap input = new ItemMap();
@@ -129,7 +129,7 @@ public class WordBankRecipe extends InputRecipe {
 		if (!ItemUtils.isValidItem(toApply)) {
 			return false;
 		}
-		if (ItemUtils.getDisplayName(toApply) != null) {
+		if (!ItemUtils.getDisplayName(toApply).isEmpty()) {
 			return false;
 		}
 		for (int i = 1; i < inputInv.getSize(); i++) {


### PR DESCRIPTION
Closes #3 

ItemUtils#getDisplayName is not returning null for items with no display name, but rather returning an empty string, thus always returning false when the recipe checks if enough materials are available.

Changing this to an is empty check appears to restore the originally intended behaviour; items with no display name are accepted, and items with a display name are rejected.
![fmod](https://user-images.githubusercontent.com/38970841/168451010-0f9e54a3-9974-426d-ad42-4f369263d219.png)

