### PR TITLE
Combine printing plate pages when printing notes

### DIFF
--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
@@ -89,7 +89,7 @@ public class PrintNoteRecipe extends PrintBookRecipe {
 	private BookInfo getBookInfo(ItemStack printingPlateStack) {
 		ItemStack book = createBook(printingPlateStack, 1);
 		BookMeta bookMeta = (BookMeta) book.getItemMeta();
-		String text = bookMeta.getPageCount() > 0 ? bookMeta.getPage(1) : "";
+		String text = bookMeta.getPageCount() > 0 ? String.join("\n", bookMeta.getPages()) : "";
 		String[] lines = text.split("\n");
 		List<String> fixedLines = new ArrayList<>();
 

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
@@ -6,8 +6,11 @@ package com.github.igotyou.FactoryMod.recipes;
 
 import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
+
 import java.util.ArrayList;
 import java.util.List;
+
+import net.minecraft.nbt.CompoundTag;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
@@ -89,7 +92,10 @@ public class PrintNoteRecipe extends PrintBookRecipe {
 	private BookInfo getBookInfo(ItemStack printingPlateStack) {
 		ItemStack book = createBook(printingPlateStack, 1);
 		BookMeta bookMeta = (BookMeta) book.getItemMeta();
-		String text = bookMeta.getPageCount() > 0 ? String.join("\n", bookMeta.getPages()) : "";
+		int version = getVersion(printingPlateStack);
+		String text = bookMeta.getPageCount() > 0 ?
+				version == 0 ? bookMeta.getPage(1) 	: String.join("", bookMeta.getPages())
+				: "";
 		String[] lines = text.split("\n");
 		List<String> fixedLines = new ArrayList<>();
 
@@ -105,13 +111,20 @@ public class PrintNoteRecipe extends PrintBookRecipe {
 		info.lines = fixedLines;
 		info.title = bookTitle != null && bookTitle.length() > 0 ? bookTitle : this.title;
 
-		if(this.secureNote) {
+		if (this.secureNote) {
 			net.minecraft.world.item.ItemStack bookItem = CraftItemStack.asNMSCopy(printingPlateStack);
 			String bookSN = bookItem.getTag().getString("SN");
 			info.lines.add(bookSN);
 		}
 
 		return info;
+	}
+
+	private int getVersion(ItemStack item) {
+		var book = CraftItemStack.asNMSCopy(item);
+		var tag = book.getTag();
+		if (tag != null && tag.contains("Version")) return tag.getInt("Version");
+		return 0;
 	}
 
 	@Override

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
@@ -89,7 +89,7 @@ public class PrintNoteRecipe extends PrintBookRecipe {
 	private BookInfo getBookInfo(ItemStack printingPlateStack) {
 		ItemStack book = createBook(printingPlateStack, 1);
 		BookMeta bookMeta = (BookMeta) book.getItemMeta();
-		String text = bookMeta.getPageCount() > 0 ? String.join("\n", bookMeta.getPages()) : "";
+		String text = bookMeta.getPageCount() > 0 ? String.join("", bookMeta.getPages()) : "";
 		String[] lines = text.split("\n");
 		List<String> fixedLines = new ArrayList<>();
 

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateRecipe.java
@@ -26,6 +26,7 @@ import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 
 public class PrintingPlateRecipe extends PrintingPressRecipe {
 	public static final String itemName = "Printing Plate";
+	private static final int version = 1;
 
 	protected ItemMap output;
 
@@ -85,6 +86,7 @@ public class PrintingPlateRecipe extends PrintingPressRecipe {
 
 		plateTag.putString("SN", serialNumber);
 		plateTag.put("Book", bookTag);
+		plateTag.putInt("Version", version);
 
 		nmsPlate.setTag(plateTag);
 		return CraftItemStack.asBukkitCopy(nmsPlate);


### PR DESCRIPTION
This joins the pages of printing plates when printing notes with newlines.
Previously, printing notes would only consider the first page of the printing plate, so any content past the first page would be ignored. However, this severely limited the amount of content that could be put into notes, such as formatting, coloring, and wide unicode characters. With this change, more content can be added to the notes by creating more pages, and each page will be joined by a newline.
