### PR TITLE
Fix 0 replacing with 7 in hex color codes

### DIFF
--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
@@ -95,7 +95,7 @@ public class PrintNoteRecipe extends PrintBookRecipe {
 
 		for (String line : lines) {
 			fixedLines.add(ChatColor.GRAY + line
-					.replaceAll(ChatColor.BLACK.toString(), ChatColor.GRAY.toString())
+					.replaceAll("(?<!§x(§[\\da-f]){0,5})" + ChatColor.BLACK, ChatColor.GRAY.toString())
 					.replaceAll(ChatColor.RESET.toString(), ChatColor.GRAY.toString()));
 		}
 


### PR DESCRIPTION
Fixes #23.

This replaces the "§0" search string with a regular expression to prevent colors in hex color codes from being incorrectly replaced.
Existing notes will not break, unless if it's using broken color codes. However, I don't think anyone would be unhappy with broken color codes being fixed.