### PR TITLE
Increase the generation of printed books

### DIFF
--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintBookRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintBookRecipe.java
@@ -2,9 +2,11 @@ package com.github.igotyou.FactoryMod.recipes;
 
 import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
+
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+
 import net.minecraft.nbt.CompoundTag;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -12,9 +14,12 @@ import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+
+import javax.annotation.Nullable;
 
 public class PrintBookRecipe extends PrintingPressRecipe {
 	private ItemMap printingPlate;
@@ -59,6 +64,7 @@ public class PrintBookRecipe extends PrintingPressRecipe {
 				&& toRemove.removeSafelyFrom(inputInv)
 		) {
 			ItemStack book = createBook(printingPlateStack, this.outputAmount);
+			book.editMeta(BookMeta.class, x -> x.setGeneration(getNextGeneration(x.getGeneration())));
 			outputInv.addItem(book);
 		}
 
@@ -75,6 +81,15 @@ public class PrintBookRecipe extends PrintingPressRecipe {
 		newBook.setTag(tag);
 
 		return CraftItemStack.asBukkitCopy(newBook);
+	}
+
+	protected BookMeta.Generation getNextGeneration(@Nullable BookMeta.Generation generation) {
+		if (generation == null) generation = BookMeta.Generation.ORIGINAL;
+		return switch (generation) {
+			case ORIGINAL -> BookMeta.Generation.COPY_OF_ORIGINAL;
+			case COPY_OF_ORIGINAL -> BookMeta.Generation.COPY_OF_COPY;
+			default -> BookMeta.Generation.TATTERED;
+		};
 	}
 
 	@Override

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateJsonRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateJsonRecipe.java
@@ -42,7 +42,9 @@ public class PrintingPlateJsonRecipe extends PrintingPlateRecipe {
 
 	@Override
 	public boolean enoughMaterialAvailable(Inventory inputInv) {
-		String[] pages = String.join("", ((BookMeta) getBook(inputInv).getItemMeta()).getPages()).split("<<PAGE>>");
+		ItemStack book = getBook(inputInv);
+		if (book == null) return false;
+		String[] pages = String.join("", ((BookMeta) book.getItemMeta()).getPages()).split("<<PAGE>>");
 
 		for (String page : pages) {
 			try {

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateRecipe.java
@@ -51,7 +51,7 @@ public class PrintingPlateRecipe extends PrintingPressRecipe {
 		ItemStack book = getBook(inputInv);
 		BookMeta bookMeta = (BookMeta)book.getItemMeta();
 		if (!bookMeta.hasGeneration()){
-			bookMeta.setGeneration(Generation.TATTERED);
+			bookMeta.setGeneration(Generation.ORIGINAL);
 		}
 		String serialNumber = UUID.randomUUID().toString();
 
@@ -70,7 +70,7 @@ public class PrintingPlateRecipe extends PrintingPressRecipe {
 						ChatColor.GRAY + getGenerationName(bookMeta.getGeneration())
 						);
 				is.addUnsafeEnchantment(Enchantment.DURABILITY, 1);
-				is.getItemMeta().addItemFlags(ItemFlag.HIDE_ENCHANTS);
+				is.editMeta(x -> x.addItemFlags(ItemFlag.HIDE_ENCHANTS));
 				outputInv.addItem(is);
 			}
 		}
@@ -148,7 +148,9 @@ public class PrintingPlateRecipe extends PrintingPressRecipe {
 
 	public ItemStack getBook(Inventory i) {
 		for (ItemStack is : i.getContents()) {
-			if (is != null && is.getType() == Material.WRITTEN_BOOK) {
+			if (is != null &&
+					is.getType() == Material.WRITTEN_BOOK &&
+					((BookMeta) is.getItemMeta()).getGeneration() != Generation.TATTERED) {
 				return is;
 			}
 		}


### PR DESCRIPTION
Resolves #15.

This makes printing presses increase the generation of printed books. For example, original books create original printing plates, which print copy of original books. Copy of original books create copy of original printing plates, which create copy of copy books. Copy of copy books create copy of copy printing plates, which create tattered books. Tattered books cannot be used to create printing plates.