### PR TITLE
Update recipe auto-select logic to consider disrepair status

### DIFF
--- a/paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
@@ -281,8 +281,9 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
 					setRecipe(autoRepair);
 				}
 			}
-			if (!hasInputMaterials() || (!rm.inDisrepair() && (currentRecipe instanceof  RepairRecipe))) {
-				//Let autoselect find something to run that isn't the repair recipe
+
+			// If we run out of input materials, try to auto-select a new recipe
+			if (!hasInputMaterials()) {
 				IRecipe autoSelected = getAutoSelectRecipe();
 				if (autoSelected == null) {
 					if (p != null) {
@@ -672,18 +673,28 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
 	}
 
 	/**
-	 * @return a recipe which the factory contains enough ressources to run except repair type recipes,
-	 * returns null if none exists
-	 *
+	 * Auto-selects a recipe which has enough materials to run given the current state of the factory.
+	 * @return null if no suitable recipe was found
 	 */
-
 	public IRecipe getAutoSelectRecipe() {
-		for (IRecipe rec : recipes) {
-			if (rec.enoughMaterialAvailable(getInventory()) && !(rec instanceof RepairRecipe)) {
-				return rec;
-			}
+		var selectedRecipe = recipes.stream()
+				.filter(it -> {
+					// We want to select a repair recipe if and only if the factory is in disrepair
+					if (rm.inDisrepair()) {
+						return it instanceof RepairRecipe;
+					} else {
+						return !(it instanceof RepairRecipe);
+					}
+				})
+				.filter(it -> it.enoughMaterialAvailable(getInputInventory()))
+				.findFirst()
+				.orElse(null);
+
+		if (selectedRecipe != null) {
+			LoggingUtils.log("Auto-selected recipe " + selectedRecipe.getName());
 		}
-		return null;
+
+		return selectedRecipe;
 	}
 
 	/**


### PR DESCRIPTION
### Summary of changes

This PR updates the auto-selection logic to support automatic selection of the repair recipe, but if and only if the factory is in disrepair.

Effectively this means that the repair recipe will never be chosen as long as the factory has health, however once it goes into disrepair, the repair recipe is the only one that will be eligible for auto-selection.

Fixes #1 

### Testing

In a local dev branch, I was able to reproduce this bug in a unit test by importing a bunch of test utility files I had originally written for ExilePearl. I kept that test code out of this PR, however you can view the specific test that was failing in my [personal dev branch](https://github.com/dquist/FactoryMod/blob/e65834e7a15a92645df89612de28b35ac475f9d3/paper/src/test/kotlin/com/github/igotyou/FactoryMod/FurnCraftChestFactoryTest.kt#L155-L171).

I will also load this into my local dev sever, but wanted to get 👀 on it in the meantime.

Update - loaded and verified in my local dev server. I manually selected a production recipe (Bake Bread), and when I tried to activate it auto-selected to repair recipe, but then did not run because the repair materials are not present.

There's room for improving the message handling here, but this fixes the bug and I'd like to do some additional cleanup in a follow-up PR.

![image](https://user-images.githubusercontent.com/3596043/227259298-39f6d6f5-4b78-41f9-8aad-d0f84422a882.png)
