### PR TITLE
Evaluate feasibility of recipe output when activating factory

### DIFF
--- a/paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
@@ -333,6 +333,16 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
 			return;
 		}
 
+		// Ensure the recipe effect can be applied
+		var effectFeasibility = currentRecipe.evaluateEffectFeasibility(getInputInventory(), getOutputInventory());
+		if (!(effectFeasibility.isFeasible())) {
+			LoggingUtils.log(String.format("Skipping activation of recipe [%s], since the effect wasn't feasible.", currentRecipe.getName()));
+			if (p != null) {
+				p.sendMessage(String.format("%sUnable to activate recipe because %s.",ChatColor.RED, effectFeasibility.reasonSnippet()));
+			}
+			return;
+		}
+
 		if (!onStartUp && currentRecipe instanceof Upgraderecipe && FactoryMod.getInstance().getManager().isCitadelEnabled()) {
 			// only allow permitted members to upgrade the factory
 			Reinforcement rein = ReinforcementLogic.getReinforcementAt(mbs.getCenter());

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/DecompactingRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/DecompactingRecipe.java
@@ -4,6 +4,7 @@ import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
 import org.bukkit.Material;
@@ -41,6 +42,26 @@ public class DecompactingRecipe extends InputRecipe {
 			}
 		}
 		return false;
+	}
+
+	@Override
+	public EffectFeasibility evaluateEffectFeasibility(Inventory inputInv, Inventory outputInv) {
+		boolean isFeasible = Arrays.stream(inputInv.getContents())
+				.filter(Objects::nonNull)
+				.filter(this::isDecompactable)
+				.map(it -> {
+					ItemStack removeClone = it.clone();
+					removeClone.setAmount(1);
+					removeCompactLore(removeClone);
+					ItemMap toAdd = new ItemMap(removeClone);
+					toAdd.addItemAmount(removeClone, CompactingRecipe.getCompactStackSize(removeClone.getType()));
+					return toAdd;
+				})
+				.allMatch(it -> it.fitsIn(outputInv));
+		return new EffectFeasibility(
+				isFeasible,
+				isFeasible ? null : "it ran out of storage space"
+		);
 	}
 
 	@Override

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/EffectFeasibility.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/EffectFeasibility.java
@@ -1,0 +1,10 @@
+package com.github.igotyou.FactoryMod.recipes;
+
+import javax.annotation.Nullable;
+
+/**
+ * Captures the feasibility of applying a recipe effect along with an optional reason string.
+ * The reason string should be plaintext and formatted such that it can be inserted in a
+ * player message that reads like "The factory couldn't run because {reasonSnippet}."
+ */
+public record EffectFeasibility(boolean isFeasible, @Nullable String reasonSnippet) { }

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/IRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/IRecipe.java
@@ -35,6 +35,15 @@ public interface IRecipe {
 	public boolean enoughMaterialAvailable(Inventory inputInv);
 
 	/**
+	 * Evaluates whether it's currently feasible to apply the recipe effect, given the constraints of the factory,
+	 * input/output inventories, or other custom recipe logic.
+	 * By default, this method returns a result indicating that the effect is always feasible to be applied.
+	 */
+	default public EffectFeasibility evaluateEffectFeasibility(Inventory inputInv, Inventory outputInv) {
+		return new EffectFeasibility(true, null);
+	}
+
+	/**
 	 * Applies whatever the recipe actually does, it's main functionality
 	 *
 	 * @param inputInv  Inventory which contains the materials to work with

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/ProductionRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/ProductionRecipe.java
@@ -113,6 +113,16 @@ public class ProductionRecipe extends InputRecipe {
 	}
 
 	@Override
+	public EffectFeasibility evaluateEffectFeasibility(Inventory inputInv, Inventory outputInv) {
+		boolean isFeasible = input.fitsIn(outputInv);
+		String reasonSnippet = isFeasible ? null : "it ran out of storage space";
+		return new EffectFeasibility(
+				isFeasible,
+				reasonSnippet
+		);
+	}
+
+	@Override
 	public boolean applyEffect(Inventory inputInv, Inventory outputInv, FurnCraftChestFactory fccf) {
 		MultiInventoryWrapper combo = new MultiInventoryWrapper(inputInv, outputInv);
 		logBeforeRecipeRun(combo, fccf);


### PR DESCRIPTION
### Summary of changes

Currently, a factory will activate and run even when there is no room for the output to be placed in the output chest. This is because a recipe only evaluates whether the output will fit when it is applying the recipe effect after completion of the run. This results in wasted charcoal and unnecessarily runs the recipe even if it will always fail.

This PR introduces a new recipe method `evaluateEffectFeasibility()` that evaluates whether a recipe can be applied before activating the factory. This means that the factory will never turn in the first place if there is no room for the contents in the chest. The feasibility check doesn't need to be limited to a chest inventory check, but could be made to check any other recipe-specific condition prior to factory activation.

By default, this method returns a truthy result to imitate current behavior, but I updated the Production and Decompaction recipes with implementations to check if the results fit, since these are the two recipes most likely to run unnecessarily.

### Testing

Ran on my local dev server and verified the factories don't run if the chests are full. Upon removing a stack, the factory can then be activated again.

Closes #1 

Showing the factory chest is full, with some compacted stone.

![2023-03-24_15 52 03](https://user-images.githubusercontent.com/3596043/227644183-6cc537b2-e4c4-4ca4-91fd-6af7c629ca02.png)

Factory wont' activate.

![2023-03-24_15 52 20](https://user-images.githubusercontent.com/3596043/227644192-d0670524-05cd-424e-ab60-82d049b219a0.png)
![image](https://user-images.githubusercontent.com/3596043/227644495-09c69bab-29e9-4f17-896a-3bcbf34e95cb.png)

Factory activates after removing a stack.

![2023-03-24_15 52 39](https://user-images.githubusercontent.com/3596043/227644204-ed86c69e-ce80-4d8f-bbeb-725cc3667fcc.png)


