### PR TITLE
Fix compacting/decompacting of lored and enchanted items

### DIFF
--- a/paper/src/main/java/com/github/igotyou/FactoryMod/listeners/CompactItemListener.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/listeners/CompactItemListener.java
@@ -1,12 +1,18 @@
 package com.github.igotyou.FactoryMod.listeners;
 
 import com.github.igotyou.FactoryMod.FactoryMod;
+import com.github.igotyou.FactoryMod.events.FactoryActivateEvent;
+import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
+import com.github.igotyou.FactoryMod.recipes.WordBankRecipe;
+import com.github.igotyou.FactoryMod.events.RecipeExecuteEvent;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.enchantment.EnchantItemEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.CraftingInventory;
@@ -51,6 +57,18 @@ public class CompactItemListener implements Listener {
 	}
 
 	/**
+	 * Prevents players from enchanting compacted items
+	 */
+	@EventHandler
+	public void enchantEvent(EnchantItemEvent e) {
+		ItemStack ei = e.getItem();
+		if (isCompacted(ei)) {
+			e.setCancelled(true);
+			e.getEnchanter().sendMessage(ChatColor.RED + "You can not enchant compacted items");
+		}
+	}
+
+	/**
 	 * Prevents players from eating compacted items
 	 */
 	@EventHandler
@@ -58,6 +76,22 @@ public class CompactItemListener implements Listener {
 		if (isCompacted(e.getItem())) {
 			e.setCancelled(true);
 			e.getPlayer().sendMessage(ChatColor.RED + "You can not eat compacted food");
+		}
+
+	}
+
+	/**
+	 * Prevents players from wordbanking compacted items
+	 */
+	@EventHandler
+	public void wordbankEvent(FactoryActivateEvent e) {
+		FurnCraftChestFactory fac = ((FurnCraftChestFactory) e.getFactory());
+
+		if (!fac.getCurrentRecipe().getTypeIdentifier().equals("WORDBANK")) return;
+
+		if (isCompacted(fac.getInputInventory().getItem(0))) {
+			e.setCancelled(true);
+			e.getActivator().sendMessage(ChatColor.RED + "You can not wordbank compacted items");
 		}
 
 	}

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/listeners/CompactItemListener.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/listeners/CompactItemListener.java
@@ -3,25 +3,26 @@ package com.github.igotyou.FactoryMod.listeners;
 import com.github.igotyou.FactoryMod.FactoryMod;
 import com.github.igotyou.FactoryMod.events.FactoryActivateEvent;
 import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
-import com.github.igotyou.FactoryMod.recipes.WordBankRecipe;
-import com.github.igotyou.FactoryMod.events.RecipeExecuteEvent;
+import io.papermc.paper.event.player.PlayerLoomPatternSelectEvent;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.entity.HumanEntity;
-import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.enchantment.EnchantItemEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.CraftingInventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.LoomInventory;
 import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * Used to handle events related to items with compacted lore
- *
  */
 public class CompactItemListener implements Listener {
 
@@ -48,8 +49,7 @@ public class CompactItemListener implements Listener {
 				e.setCancelled(true);
 				HumanEntity h = e.getWhoClicked();
 				if (h instanceof Player) {
-					((Player) h)
-							.sendMessage(ChatColor.RED + "You can not craft with compacted items");
+					h.sendMessage(ChatColor.RED + "You can not craft with compacted items");
 				}
 				break;
 			}
@@ -77,7 +77,6 @@ public class CompactItemListener implements Listener {
 			e.setCancelled(true);
 			e.getPlayer().sendMessage(ChatColor.RED + "You can not eat compacted food");
 		}
-
 	}
 
 	/**
@@ -93,7 +92,80 @@ public class CompactItemListener implements Listener {
 			e.setCancelled(true);
 			e.getActivator().sendMessage(ChatColor.RED + "You can not wordbank compacted items");
 		}
+	}
 
+	/**
+	 * Prevents players from using compacted items in anvils
+	 */
+	@EventHandler
+	public void anvilEvent(InventoryClickEvent e) {
+		if (e.getCurrentItem() == null) return;
+
+		if (e.getCurrentItem().getType() == Material.AIR) return;
+
+		if (e.getInventory().getType() == InventoryType.ANVIL) {
+			if (e.getSlotType() == InventoryType.SlotType.RESULT) {
+				if (isCompacted(e.getInventory().getItem(0)) || isCompacted(e.getInventory().getItem(1))) {
+					e.setCancelled(true);
+					e.getWhoClicked().sendMessage(ChatColor.RED + "You can not use compacted items in an anvil");
+				}
+			}
+		}
+	}
+
+	/**
+	 * Prevents players from using compacted items in smithing tables
+	 */
+	@EventHandler
+	public void smithEvent(InventoryClickEvent e) {
+		if (e.getCurrentItem() == null) return;
+
+		if (e.getCurrentItem().getType() == Material.AIR) return;
+
+		if (e.getInventory().getType() == InventoryType.SMITHING) {
+			if (e.getSlotType() == InventoryType.SlotType.RESULT) {
+				if (isCompacted(e.getInventory().getItem(0)) || isCompacted(e.getInventory().getItem(1))) {
+					e.setCancelled(true);
+					e.getWhoClicked().sendMessage(ChatColor.RED + "You can not use compacted items in a smithing table");
+				}
+			}
+		}
+	}
+
+	/**
+	 * Prevents players from using compacted items in looms
+	 */
+	@EventHandler
+	public void loomEvent(PlayerLoomPatternSelectEvent e) {
+		LoomInventory li = e.getLoomInventory();
+
+		for (int i = 0; i < 2; i++) {
+			if (li.getItem(i) == null) continue;
+			if (li.getItem(i).getType() == Material.AIR) continue;
+			if (isCompacted(li.getItem(i))) {
+				e.setCancelled(true);
+				e.getPlayer().sendMessage(ChatColor.RED + "You can not use compacted items in a loom");
+			}
+		}
+	}
+
+	/**
+	 * Prevents players from copying compacted maps in cartography tables
+	 */
+	@EventHandler
+	public void cartographyCopyEvent(InventoryClickEvent e) {
+		if (e.getCurrentItem() == null) return;
+
+		if (e.getCurrentItem().getType() == Material.AIR) return;
+
+		if (e.getInventory().getType() == InventoryType.CARTOGRAPHY) {
+			if (e.getSlotType() == InventoryType.SlotType.RESULT) {
+				if (isCompacted(e.getInventory().getItem(0)) || isCompacted(e.getInventory().getItem(1))) {
+					e.setCancelled(true);
+					e.getWhoClicked().sendMessage(ChatColor.RED + "You can not copy compacted maps");
+				}
+			}
+		}
 	}
 
 	private boolean isCompacted(ItemStack is) {
@@ -107,7 +179,7 @@ public class CompactItemListener implements Listener {
 		if (!im.hasLore()) {
 			return false;
 		}
-		for(String lore : im.getLore()) {
+		for (String lore : im.getLore()) {
 			if (FactoryMod.getInstance().getManager().isCompactLore(lore)) {
 				return true;
 			}

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/CompactingRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/CompactingRecipe.java
@@ -2,9 +2,8 @@ package com.github.igotyou.FactoryMod.recipes;
 
 import com.github.igotyou.FactoryMod.FactoryMod;
 import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
+
+import java.util.*;
 
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
 import org.bukkit.Material;
@@ -12,6 +11,7 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemMap;
 import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
+import vg.civcraft.mc.civmodcore.inventory.items.MetaUtils;
 
 /**
  * Used to compact items, which means whole or multiple stacks of an item are reduced to a single lored item, which is stackable to the same stacksize
@@ -176,14 +176,11 @@ public class CompactingRecipe extends InputRecipe {
 	 */
 	private boolean compactable(ItemStack is, ItemMap im) {
 		if (is == null || excludedMaterials.contains(is.getType()) || (input.getAmount(is) != 0) || (is.getItemMeta().getLore() != null &&
-				is.getItemMeta().getLore().contains(compactedLore)) || (is.getItemMeta().hasEnchants() && is.getType().getMaxStackSize() == 1)) {
+				is.getItemMeta().getLore().contains(compactedLore))) {
 			return false;
-		}	
-		if (im.getAmount(is) >= getCompactStackSize(is.getType())) {
-			return true;
-		} 
-		return false;
-	}
+		}
+        return im.getAmount(is) >= getCompactStackSize(is.getType());
+    }
 
 	@Override
 	public String getTypeIdentifier() {

--- a/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/DecompactingRecipe.java
+++ b/paper/src/main/java/com/github/igotyou/FactoryMod/recipes/DecompactingRecipe.java
@@ -148,11 +148,6 @@ public class DecompactingRecipe extends InputRecipe {
 	}
 
 	private boolean isDecompactable(ItemStack is) {
-		//dont allow decompation if the item is enchanted or has additional lore, as the enchant/additional lore could have been applied to the compacted item
-		//and decompacting it would produce many items, which all have that enchant/lore
-		if (((is.getItemMeta().hasEnchants() || (is.getItemMeta().hasLore() && is.getItemMeta().getLore().size() >= 2)) && is.getType().getMaxStackSize() == 1)) {
-			return false;
-		}
 		List <String> lore = is.getItemMeta().getLore();
 		if (lore != null) {
 			for(String content : lore) {
@@ -182,7 +177,7 @@ public class DecompactingRecipe extends InputRecipe {
 	public String getCompactedLore() {
 		return compactedLore;
 	}
-	
+
 	@Override
 	public List<String> getTextualOutputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
 		return Arrays.asList("An entire stack of the decompacted item if it's stackable", "---OR---", "Eight of the decompacted item if it's not stackable");


### PR DESCRIPTION
Restricts enchanting, wordbanking, smithing, anvil use, loom use, and cartography table use of compacted items so that the check for lore and enchants when decompacting is no longer necessary. Requires https://github.com/CivMC/CivModCore/pull/87 to be merged to work correctly.